### PR TITLE
github_sync: smarter target branch selection

### DIFF
--- a/kernel_patches_daemon/branch_worker.py
+++ b/kernel_patches_daemon/branch_worker.py
@@ -351,9 +351,9 @@ async def send_email(
         email_send_fail_counter.add(1)
 
 
-def _is_pr_flagged(pr: PullRequest) -> bool:
-    for label in pr.get_labels():
-        if MERGE_CONFLICT_LABEL == label.name:
+def pr_has_label(pr: PullRequest, label: str) -> bool:
+    for l in pr.get_labels():
+        if l.name == label:
             return True
     return False
 
@@ -855,7 +855,7 @@ class BranchWorker(GithubConnector):
 
         if pr:
             if (not has_merge_conflict) or (
-                has_merge_conflict and not _is_pr_flagged(pr)
+                has_merge_conflict and not pr_has_label(pr, MERGE_CONFLICT_LABEL)
             ):
                 if message:
                     self._add_pull_request_comment(pr, message)
@@ -1109,7 +1109,7 @@ class BranchWorker(GithubConnector):
         pr.update()
         # if it's merge conflict - report failure
         ctx = BranchWorker.slugify_context(f"{CI_DESCRIPTION}-{self.repo_branch}")
-        if _is_pr_flagged(pr):
+        if pr_has_label(pr, MERGE_CONFLICT_LABEL):
             await series.set_check(
                 status=Status.CONFLICT,
                 target_url=pr.html_url,


### PR DESCRIPTION
Implement "sticky" target branch: if a series has an associated open
PR without merge-conflict, then do not consider other target branches.

The config allows for multiple target branches to be associated with
the same tag, for example:

  "tag_to_branch_mapping": {
    "tag": ["target1", "target2"]
  }

Whenever a series is being synced, KPD tries to apply it to each
target branch in order, stopping at the first successful apply.  Then
it opens/updates a tracking PR, and closes all other PRs for this
series.

This works fine most of the time. However, this logic may lead to
series suddenly switching branches. Example scenario:

* v1 successfully applied to target1, pr1 is created for it
  * submitter receives CI report with v1 applied to target1
* v2 fails to apply to target1, but succeeds on target2
  * KPD opens pr2 for target2, and closes pr1
  * submitter receives CI report with v2 applied to target2 with no
    indication that something happened

What should've happened in this case is pr1 labeled as
"merge-conflict" and target2 not tried.

The "stickiness" is implemented by checking existing PRs when
determining the list of target branches to apply the series to.
