### PR TITLE
Fix docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-buster as builder
+FROM python:3.9-bullseye as builder
 
 RUN pip install poetry
 
@@ -9,13 +9,13 @@ ENV POETRY_NO_INTERACTION=1 \
 
 WORKDIR /app
 
-COPY pyproject.toml poetry.lock ./
+COPY pyproject.toml /app/pyproject.toml
 RUN touch README.md
 
 RUN poetry install --without dev --no-root && rm -rf $POETRY_CACHE_DIR
 
 # The runtime image, used to just run the code provided its virtual environment
-FROM python:3.10-slim-buster as runtime
+FROM python:3.9-bullseye as runtime
 LABEL maintainer="Ihor Solodrai <isolodrai@meta.com>"
 
 RUN apt update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN poetry install --without dev --no-root && rm -rf $POETRY_CACHE_DIR
 
 # The runtime image, used to just run the code provided its virtual environment
 FROM python:3.10-slim-buster as runtime
-LABEL maintainer="Nikolay Yurin <yurinnick@meta.com>"
+LABEL maintainer="Ihor Solodrai <isolodrai@meta.com>"
 
 RUN apt update && \
     apt install -y git && \


### PR DESCRIPTION
poetry.lock was removed from version control [1], but the Dockerfile
was not updated.

Also change the base image to python:3.9-bullseye
Debian buster has been discontinued [2], so bump to bullseye.
And python 3.9 is the minimal requried version at this time.

[1] https://github.com/kernel-patches/kernel-patches-daemon/commit/ff326f3be8f014557a82ca98114fa336046bd5ee
[2] https://www.debian.org/releases/buster/