### PR TITLE
lint: apply usort

### DIFF
--- a/kernel_patches_daemon/branch_worker.py
+++ b/kernel_patches_daemon/branch_worker.py
@@ -38,9 +38,9 @@ from github.Repository import Repository
 from github.WorkflowJob import WorkflowJob
 
 from kernel_patches_daemon.config import (
+    EmailConfig,
     SERIES_ID_SEPARATOR,
     SERIES_TARGET_SEPARATOR,
-    EmailConfig,
 )
 from kernel_patches_daemon.github_connector import GithubConnector
 from kernel_patches_daemon.github_logs import GithubFailedJobLog, GithubLogExtractor
@@ -352,8 +352,8 @@ async def send_email(
 
 
 def pr_has_label(pr: PullRequest, label: str) -> bool:
-    for l in pr.get_labels():
-        if l.name == label:
+    for pr_label in pr.get_labels():
+        if pr_label.name == label:
             return True
     return False
 

--- a/kernel_patches_daemon/github_sync.py
+++ b/kernel_patches_daemon/github_sync.py
@@ -14,18 +14,18 @@ from typing import Dict, Final, List, Optional, Sequence
 from github import Auth
 from github.PullRequest import PullRequest
 from kernel_patches_daemon.branch_worker import (
-    MERGE_CONFLICT_LABEL,
     BranchWorker,
+    MERGE_CONFLICT_LABEL,
+    NewPRWithNoChangeException,
+    parse_pr_ref,
     parsed_pr_ref_ok,
     pr_has_label,
     same_series_different_target,
-    parse_pr_ref,
-    NewPRWithNoChangeException,
 )
 from kernel_patches_daemon.config import (
-    SERIES_TARGET_SEPARATOR,
     BranchConfig,
     KPDConfig,
+    SERIES_TARGET_SEPARATOR,
 )
 from kernel_patches_daemon.github_logs import (
     BpfGithubLogExtractor,

--- a/tests/test_branch_worker.py
+++ b/tests/test_branch_worker.py
@@ -40,8 +40,8 @@ from kernel_patches_daemon.branch_worker import (
 )
 from kernel_patches_daemon.config import (
     EmailConfig,
-    SERIES_TARGET_SEPARATOR,
     SERIES_ID_SEPARATOR,
+    SERIES_TARGET_SEPARATOR,
 )
 from kernel_patches_daemon.github_logs import DefaultGithubLogExtractor
 from kernel_patches_daemon.patchwork import Series, Subject

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -20,11 +20,7 @@ from kernel_patches_daemon.branch_worker import (
 )
 from kernel_patches_daemon.config import KPDConfig, SERIES_TARGET_SEPARATOR
 from kernel_patches_daemon.github_sync import GithubSync
-from tests.common.patchwork_mock import (
-    init_pw_responses,
-    load_test_data,
-    PatchworkMock,
-)
+from tests.common.patchwork_mock import init_pw_responses, load_test_data, PatchworkMock
 
 TEST_BRANCH = "test-branch"
 TEST_BPF_NEXT_BRANCH = "test-bpf-next"


### PR DESCRIPTION
Meta's internal linter also applies usort to import, so do that.
Also rename `l` to `pr_label` in pr_has_label().