### PR TITLE
branch_worker: introduce can_do_sync() check

### DIFF
--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -85,6 +85,10 @@ class TestGithubSync(unittest.IsolatedAsyncioTestCase):
         self.addCleanup(patcher.stop)
 
         self._gh = GithubSyncMock()
+        for worker in self._gh.workers.values():
+            rate_limit = MagicMock()
+            rate_limit.core.remaining = 5000
+            worker.git.get_rate_limit = MagicMock(return_value=rate_limit)
 
     def test_init_with_base_directory(self) -> None:
         @dataclass


### PR DESCRIPTION
Github has a limit on the number of tokens used by an app, which is 5k/1h for a free-tier org [1].

In BPF CI due to number of pending PRs, we regularly get very close to hitting the limit (remaining < 500) and have relevant alerts set up.

Introduce can_do_sync() method to BranchWorker that will check if there is enough remaining tokens to run through the sync_patches. *Enough* is defined by MIN_REMAINING_GITHUB_TOKENS, which is currently a constant for simplicity.

In case the number of remaining tokens is too low, the sync_patches will simply be skipped for the worker. Effectively KPD will wait until github will refresh the limit without crashing.

[1] https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-authenticated-users