### PR TITLE
kpd: add optional mirror support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ poetry install
 poetry run python -m unittest
 ```
 
+### Mirror setup
+
+To make more efficient use of network bandwidth consider having a mirror of your target git tree
+under /mirror/ or something like that and set the configuration attribute "mirror_dir" variable to the
+path where to find possible git trees.
+
+If your git tree is a linux clone set the "linux_clone" to true. In that case, in case your
+target exact basename repo is not in in the mirror path, for example {{ mirror_dir }}/linux-subsystem.git
+then the extra fallback path of {{ mirror_dir }}/linux.git will be used as a reference target.
+
+A reference target mirror path is only used if it exists. The mirror takes effect by leveraging
+the git clone --reference option when cloning. Using this can save considerable bandwidth and
+space, allowing kpd to run on thing guests on a corporate environment with for example an NFS
+mount for local git trees on a network.
+
 ## Running
 ```
 poetry run python -m kernel_patches_daemon --config <config_path> --label-color configs/labels.json

--- a/configs/kpd.json
+++ b/configs/kpd.json
@@ -41,5 +41,7 @@
       "github_oauth_token": "<TOKEN>"
     }
   },
-  "base_directory": "/tmp/repos"
+  "base_directory": "/tmp/repos",
+  "mirror_dir": "/mirror/",
+  "linux_clone": true
 }

--- a/kernel_patches_daemon/config.py
+++ b/kernel_patches_daemon/config.py
@@ -171,6 +171,8 @@ class KPDConfig:
     branches: Dict[str, BranchConfig]
     tag_to_branch_mapping: Dict[str, List[str]]
     base_directory: str
+    mirror_dir: Optional[str] = None
+    linux_clone: bool = False
 
     @classmethod
     def from_json(cls, json: Dict) -> "KPDConfig":
@@ -203,6 +205,8 @@ class KPDConfig:
                 for name, json_config in json["branches"].items()
             },
             base_directory=json["base_directory"],
+            mirror_dir=json.get("mirror_dir"),
+            linux_clone=json.get("linux_clone", False),
         )
 
     @classmethod

--- a/kernel_patches_daemon/github_sync.py
+++ b/kernel_patches_daemon/github_sync.py
@@ -114,6 +114,8 @@ class GithubSync(Stats):
                 ci_branch=branch_config.ci_branch,
                 log_extractor=_log_extractor_from_project(kpd_config.patchwork.project),
                 base_directory=kpd_config.base_directory,
+                mirror_dir=kpd_config.mirror_dir,
+                linux_clone=kpd_config.linux_clone,
                 http_retries=http_retries,
                 github_oauth_token=branch_config.github_oauth_token,
                 app_auth=github_app_auth_from_branch_config(branch_config),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -208,5 +208,18 @@ class TestConfig(unittest.TestCase):
                 ),
             },
             base_directory="/repos",
+            mirror_dir=None,
+            linux_clone=False,
         )
         self.assertEqual(config, expected_config)
+
+    def test_linux_clone_enabled(self) -> None:
+        kpd_config_json = read_fixture("fixtures/kpd_config.json")
+        kpd_config_json["linux_clone"] = True
+
+        with patch(
+            "builtins.open", mock_open(read_data="TEST_KEY_FILE_CONTENT")
+        ):
+            config = KPDConfig.from_json(kpd_config_json)
+
+        self.assertTrue(config.linux_clone)

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -126,6 +126,20 @@ class TestGithubSync(unittest.IsolatedAsyncioTestCase):
                     gh.workers[TEST_BRANCH].ci_repo_dir.startswith(case.prefix),
                 )
 
+    def test_init_with_mirror_dir(self) -> None:
+        config = copy.copy(TEST_CONFIG)
+        config["mirror_dir"] = "/mirror"
+        kpd_config = KPDConfig.from_json(config)
+        gh = GithubSyncMock(kpd_config=kpd_config)
+        self.assertEqual("/mirror", gh.workers[TEST_BRANCH].mirror_dir)
+
+    def test_init_with_linux_clone(self) -> None:
+        config = copy.copy(TEST_CONFIG)
+        config["linux_clone"] = True
+        kpd_config = KPDConfig.from_json(config)
+        gh = GithubSyncMock(kpd_config=kpd_config)
+        self.assertTrue(gh.workers[TEST_BRANCH].linux_clone)
+
     def test_close_existing_prs_for_series(self) -> None:
         matching_pr_mock = MagicMock()
         matching_pr_mock.title = "matching"


### PR DESCRIPTION
We always clone a full repository. This is counter productive and wasteful. Allow users to specify that they are using kpd to help test patches for a git tree which we should expect a mirror on a target mirror path.

Optionally, we also allow users to clarify that their target git tree is a linux clone, and in such cases we can always fallback to looking for a mirror path with the "linux.git" name.

So for example, all kdevops enterprise deployments can easily profit from this as kdevops has support to mirror all target git trees it supports under /mirror/ through an NFS export for clients. And so small thing guests can be used for kpd instances, which can leverage this NFS export.

This allows kpd to be run on smaller guests with less storage needs. This should allow more than one kpd instance to run on small guests too.

Generated-by: ChatGPT Codex