### PR TITLE
daemon: do not crash on unhandled exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It also updates series checks at Patchwork with CI workflow results, and can sen
 
 KPD was originally developed at Meta in order to facilitate automated testing  of [BPF subsystem](https://docs.cilium.io/en/latest/reference-guides/bpf/index.html) of the [Linux Kernel](https://kernel.org/) (see [BPF CI](https://github.com/kernel-patches/bpf/actions/workflows/test.yml)).
 
-There have been a number of talks at various Linux-related conferences about KPD, see the slide decks for an introduction and overview: 
+There have been a number of talks at various Linux-related conferences about KPD, see the slide decks for an introduction and overview:
 - ["KPD: Connect LKML to GitHub"](https://github.com/user-attachments/files/21110162/KPD_.Connect.LKML.to.GitHub.pdf) (Automated Testing Summit 2025)
 - ["Get Started with KPD"](https://github.com/user-attachments/files/21110192/Get.Started.with.KPD.pdf) (2024)
 - ["How BPF CI works?"](http://oldvger.kernel.org/bpfconf2022_material/lsfmmbpf2022-bpf-ci.pdf) (LSF/MM/BPF 2022)

--- a/kernel_patches_daemon/branch_worker.py
+++ b/kernel_patches_daemon/branch_worker.py
@@ -37,10 +37,7 @@ from github.PullRequest import PullRequest
 from github.Repository import Repository
 from github.WorkflowJob import WorkflowJob
 
-from kernel_patches_daemon.config import (
-    EmailConfig,
-    SERIES_TARGET_SEPARATOR,
-)
+from kernel_patches_daemon.config import EmailConfig, SERIES_TARGET_SEPARATOR
 from kernel_patches_daemon.github_connector import GithubConnector
 from kernel_patches_daemon.github_logs import GithubLogExtractor
 from kernel_patches_daemon.patchwork import Patchwork, Series, Subject

--- a/kernel_patches_daemon/github_sync.py
+++ b/kernel_patches_daemon/github_sync.py
@@ -130,6 +130,8 @@ class GithubSync(Stats):
                 "prs_total",  # All prs within the scope of work for this worker
                 "empty_pr",  # Series that would result in an empty PR creation
                 "all_known_subjects",  # All known subjects from PW and GH, including expired patches
+                "runs_successful",  # Successful KernelPatchesWorker.run() iteration
+                "runs_failed",  # Failed KernelPatchesWorker.run() iteration
             }
         )
 

--- a/kernel_patches_daemon/github_sync.py
+++ b/kernel_patches_daemon/github_sync.py
@@ -22,10 +22,7 @@ from kernel_patches_daemon.branch_worker import (
     pr_has_label,
     same_series_different_target,
 )
-from kernel_patches_daemon.config import (
-    BranchConfig,
-    KPDConfig,
-)
+from kernel_patches_daemon.config import BranchConfig, KPDConfig
 from kernel_patches_daemon.github_logs import (
     BpfGithubLogExtractor,
     DefaultGithubLogExtractor,

--- a/kernel_patches_daemon/stats.py
+++ b/kernel_patches_daemon/stats.py
@@ -78,10 +78,15 @@ class Stats:
         for counter in DEFAULT_STATS | self.counters:
             self.stats[counter] = 0
 
-    def increment_counter(self, key: str, increment: int = 1) -> None:
-        try:
+    def increment_counter(
+        self, key: str, increment: int = 1, create: bool = False
+    ) -> None:
+        if key in self.stats:
             self.stats[key] += increment
-        except Exception:
+        elif create:
+            self.counters.add(key)
+            self.stats[key] = increment
+        else:
             self.stats[STATS_KEY_BUG] += 1
             logger.error(f"Failed to add {increment} increment to '{key}' stat")
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,0 +1,89 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import Any, Dict
+from unittest.mock import AsyncMock, patch
+
+from kernel_patches_daemon.config import KPDConfig
+from kernel_patches_daemon.daemon import KernelPatchesWorker
+
+TEST_CONFIG: Dict[str, Any] = {
+    "version": 3,
+    "patchwork": {
+        "project": "test",
+        "server": "pw",
+        "search_patterns": ["pw-search-pattern"],
+        "lookback": 7,
+    },
+    "branches": {
+        "test-branch": {
+            "repo": "repo",
+            "github_oauth_token": "test-oauth-token",
+            "upstream": "https://127.0.0.2:0/upstream_org/upstream_repo",
+            "ci_repo": "ci-repo",
+            "ci_branch": "test_ci_branch",
+        },
+    },
+    "tag_to_branch_mapping": {
+        "tag": ["test-branch"],
+        "__DEFAULT__": ["test-branch"],
+    },
+    "base_directory": "/tmp",
+}
+
+
+class TestException(Exception):
+    pass
+
+
+class TestKernelPatchesWorker(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.github_patcher = patch("kernel_patches_daemon.github_connector.Github")
+        self.github_mock = self.github_patcher.start()
+        self.addCleanup(self.github_patcher.stop)
+
+        user_mock = self.github_mock.return_value.get_user.return_value
+        user_mock.login = "test-user"
+
+        self.git_patcher = patch("kernel_patches_daemon.branch_worker.git.Repo")
+        self.git_patcher.start()
+        self.addCleanup(self.git_patcher.stop)
+
+        kpd_config = KPDConfig.from_json(TEST_CONFIG)
+        self.worker = KernelPatchesWorker(kpd_config, {})
+
+        self.worker.github_sync_worker.sync_patches = AsyncMock()
+
+    async def test_run_ok(self) -> None:
+        with (
+            patch(
+                "asyncio.sleep",
+                AsyncMock(side_effect=TestException("Test complete")),
+            ),
+            self.assertRaises(TestException),
+        ):
+            await self.worker.run()
+
+        gh_sync = self.worker.github_sync_worker
+        gh_sync.sync_patches.assert_called_once()
+        self.assertEqual(gh_sync.stats["runs_successful"], 1)
+
+    async def test_run_exception(self) -> None:
+        """Test that stats are correctly collected when an exception occurs."""
+        gh_sync = self.worker.github_sync_worker
+        gh_sync.sync_patches = AsyncMock(side_effect=ValueError("Test exception"))
+
+        with (
+            patch(
+                "asyncio.sleep", AsyncMock(side_effect=TestException("Test complete"))
+            ),
+            self.assertRaises(TestException),
+        ):
+            await self.worker.run()
+
+        self.assertEqual(gh_sync.stats["runs_failed"], 1)
+        self.assertEqual(gh_sync.stats["unhandled_ValueError"], 1)


### PR DESCRIPTION
So far the main loop in KernelPatchesWorker.run() has been counting how many unhandled exceptions happened concurrently. If it crossed a threshold (hardcoded to 5), the the last caught exceptions is raised, crashing the daemon.

This turns out to be annoying, because KPD talks to github and patchwork via network, and so whenever there are network errors or external outages (which happened in the past both with github and patchwork), the KPD service falls into a crash-restart loop.

Given that KPD can not do anything if it can't reach it's dependencies, crashes don't do anything except generating noise for whoever is operating it.

Change the handling of unhandled (ha) exceptions:
  * record the failure and exception name in stats, which are periodically pushed to configured metric_logger
  * dump the stack trace of every unhandled exception to the log, so that they can still be investigated