### PR TITLE
kpd: customize patchwork check links for AI review workflow

### DIFF
--- a/kernel_patches_daemon/branch_worker.py
+++ b/kernel_patches_daemon/branch_worker.py
@@ -1267,6 +1267,43 @@ class BranchWorker(GithubConnector):
         subj_branch = await subject.branch()
         return f"{subj_branch}{SERIES_TARGET_SEPARATOR}{self.repo_branch}"
 
+    def _find_ai_review_comment_url(
+        self, run_id: int, pr_comments: List
+    ) -> Optional[str]:
+        """Find the AI review comment URL for a given workflow run.
+
+        AI review comments contain a 'CI run summary' line embedding the run URL.
+        We match on that to find the corresponding comment.
+        """
+        run_url_suffix = f"/actions/runs/{run_id}"
+        candidates = [c for c in pr_comments if run_url_suffix in c.body]
+        if not candidates:
+            return None
+        if len(candidates) == 1:
+            return candidates[0].html_url
+        return candidates[-1].html_url
+
+    def _resolve_check_target_url(
+        self,
+        job: WorkflowJob,
+        run_metadata: Dict[int, str],
+        pr_comments: List,
+    ) -> str:
+        """Determine the target URL for a patchwork check.
+
+        For most jobs this is job.html_url (the GitHub Actions job page).
+        For failed AI Code Review jobs, this is the PR comment URL.
+        """
+        workflow_name = run_metadata.get(job.run_id, "")
+        job_status = gh_conclusion_to_status(job.conclusion)
+
+        if workflow_name == "AI Code Review" and job_status == Status.FAILURE:
+            comment_url = self._find_ai_review_comment_url(job.run_id, pr_comments)
+            if comment_url:
+                return comment_url
+
+        return job.html_url
+
     async def sync_checks(self, pr: PullRequest, series: Series) -> None:
         # Make sure that we are working with up-to-date data (as opposed to
         # cached state).
@@ -1287,6 +1324,7 @@ class BranchWorker(GithubConnector):
 
         statuses: List[Status] = []
         jobs = []
+        run_metadata: Dict[int, str] = {}
 
         # Note that we are interested in listing *all* runs and not just, say,
         # completed ones. The reason being that the information that pending
@@ -1297,6 +1335,7 @@ class BranchWorker(GithubConnector):
             head_sha=pr.head.sha,
         ):
             status = gh_conclusion_to_status(run.conclusion)
+            run_metadata[run.id] = run.name
             run_jobs = run.jobs()
 
             # Overall run failure could have many reasons, including
@@ -1329,6 +1368,13 @@ class BranchWorker(GithubConnector):
         # of jobs by name and later use the index of the test in the array to
         # generate the context name.
         jobs = sorted(jobs, key=lambda job: job.name)
+
+        has_ai_review_failures = any(
+            run_metadata.get(job.run_id) == "AI Code Review"
+            and gh_conclusion_to_status(job.conclusion) == Status.FAILURE
+            for job in jobs
+        )
+        pr_comments = list(pr.get_issue_comments()) if has_ai_review_failures else []
         jobs_logs = [
             f"{job.conclusion} -> {gh_conclusion_to_status(job.conclusion)} ({job.html_url})"
             for job in jobs
@@ -1345,7 +1391,9 @@ class BranchWorker(GithubConnector):
         ] + [
             series.set_check(
                 status=gh_conclusion_to_status(job.conclusion),
-                target_url=job.html_url,
+                target_url=self._resolve_check_target_url(
+                    job, run_metadata, pr_comments
+                ),
                 context=slugify_check_context(f"{ctx_prefix}_{job.name}"),
                 description=f"Logs for {job.name}",
             )

--- a/kernel_patches_daemon/branch_worker.py
+++ b/kernel_patches_daemon/branch_worker.py
@@ -1275,8 +1275,8 @@ class BranchWorker(GithubConnector):
         AI review comments contain a 'CI run summary' line embedding the run URL.
         We match on that to find the corresponding comment.
         """
-        run_url_suffix = f"/actions/runs/{run_id}"
-        candidates = [c for c in pr_comments if run_url_suffix in c.body]
+        run_url_pattern = rf"/actions/runs/{run_id}(?!\d)"
+        candidates = [c for c in pr_comments if re.search(run_url_pattern, c.body)]
         if not candidates:
             return None
         if len(candidates) == 1:

--- a/tests/test_branch_worker.py
+++ b/tests/test_branch_worker.py
@@ -1802,3 +1802,147 @@ class TestPRCommentBodyPreprocessor(unittest.TestCase):
         email_body = self._bw.pr_comment_body_to_email_body(cfg, comment_body)
         # Expect no change
         self.assertEqual(email_body, comment_body)
+
+
+class TestFindAiReviewCommentUrl(unittest.TestCase):
+    """Tests for BranchWorker._find_ai_review_comment_url"""
+
+    def setUp(self) -> None:
+        patcher = patch("kernel_patches_daemon.github_connector.Github")
+        self._gh_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+        self._bw = BranchWorkerMock()
+
+    def _make_comment(self, body: str, html_url: str) -> MagicMock:
+        comment = MagicMock()
+        comment.body = body
+        comment.html_url = html_url
+        return comment
+
+    def test_matching_comment_returns_url(self):
+        run_id = 12345
+        comment = self._make_comment(
+            body=f"Review feedback\nCI run summary: https://github.com/org/repo/actions/runs/{run_id}\nMore text",
+            html_url="https://github.com/org/repo/pull/1#issuecomment-100",
+        )
+        result = self._bw._find_ai_review_comment_url(run_id, [comment])
+        self.assertEqual(result, "https://github.com/org/repo/pull/1#issuecomment-100")
+
+    def test_no_matching_comment_returns_none(self):
+        comment = self._make_comment(
+            body="Some unrelated comment without run URL",
+            html_url="https://github.com/org/repo/pull/1#issuecomment-200",
+        )
+        result = self._bw._find_ai_review_comment_url(99999, [comment])
+        self.assertIsNone(result)
+
+    def test_empty_comments_returns_none(self):
+        result = self._bw._find_ai_review_comment_url(12345, [])
+        self.assertIsNone(result)
+
+    def test_multiple_matching_comments_returns_last(self):
+        run_id = 12345
+        first = self._make_comment(
+            body=f"First review\nCI run summary: https://github.com/org/repo/actions/runs/{run_id}",
+            html_url="https://github.com/org/repo/pull/1#issuecomment-100",
+        )
+        second = self._make_comment(
+            body=f"Second review\nCI run summary: https://github.com/org/repo/actions/runs/{run_id}",
+            html_url="https://github.com/org/repo/pull/1#issuecomment-200",
+        )
+        result = self._bw._find_ai_review_comment_url(run_id, [first, second])
+        self.assertEqual(result, "https://github.com/org/repo/pull/1#issuecomment-200")
+
+    def test_only_exact_run_id_matches(self):
+        comment = self._make_comment(
+            body="CI run summary: https://github.com/org/repo/actions/runs/1234",
+            html_url="https://github.com/org/repo/pull/1#issuecomment-300",
+        )
+        result = self._bw._find_ai_review_comment_url(12345, [comment])
+        self.assertIsNone(result)
+
+    def test_shorter_run_id_does_not_match_longer(self):
+        comment = self._make_comment(
+            body="CI run summary: https://github.com/org/repo/actions/runs/12345",
+            html_url="https://github.com/org/repo/pull/1#issuecomment-300",
+        )
+        result = self._bw._find_ai_review_comment_url(1234, [comment])
+        self.assertIsNone(result)
+
+
+class TestResolveCheckTargetUrl(unittest.TestCase):
+    """Tests for BranchWorker._resolve_check_target_url"""
+
+    def setUp(self) -> None:
+        patcher = patch("kernel_patches_daemon.github_connector.Github")
+        self._gh_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+        self._bw = BranchWorkerMock()
+
+    def _make_job(
+        self, run_id: int, conclusion: Optional[str], html_url: str
+    ) -> MagicMock:
+        job = MagicMock()
+        job.run_id = run_id
+        job.conclusion = conclusion
+        job.html_url = html_url
+        return job
+
+    def _make_comment(self, body: str, html_url: str) -> MagicMock:
+        comment = MagicMock()
+        comment.body = body
+        comment.html_url = html_url
+        return comment
+
+    def test_failed_ai_review_with_comment(self):
+        run_id = 55555
+        job = self._make_job(
+            run_id, "failure", "https://github.com/org/repo/actions/runs/55555/job/1"
+        )
+        run_metadata = {run_id: "AI Code Review"}
+        comment = self._make_comment(
+            body=f"Review\nCI run summary: https://github.com/org/repo/actions/runs/{run_id}",
+            html_url="https://github.com/org/repo/pull/1#issuecomment-777",
+        )
+        result = self._bw._resolve_check_target_url(job, run_metadata, [comment])
+        self.assertEqual(result, "https://github.com/org/repo/pull/1#issuecomment-777")
+
+    def test_failed_ai_review_no_comment(self):
+        run_id = 55555
+        job = self._make_job(
+            run_id, "failure", "https://github.com/org/repo/actions/runs/55555/job/1"
+        )
+        run_metadata = {run_id: "AI Code Review"}
+        result = self._bw._resolve_check_target_url(job, run_metadata, [])
+        self.assertEqual(result, "https://github.com/org/repo/actions/runs/55555/job/1")
+
+    def test_successful_ai_review(self):
+        run_id = 55555
+        job = self._make_job(
+            run_id, "success", "https://github.com/org/repo/actions/runs/55555/job/1"
+        )
+        run_metadata = {run_id: "AI Code Review"}
+        comment = self._make_comment(
+            body=f"CI run summary: https://github.com/org/repo/actions/runs/{run_id}",
+            html_url="https://github.com/org/repo/pull/1#issuecomment-777",
+        )
+        result = self._bw._resolve_check_target_url(job, run_metadata, [comment])
+        self.assertEqual(result, "https://github.com/org/repo/actions/runs/55555/job/1")
+
+    def test_failed_non_ai_workflow(self):
+        run_id = 55555
+        job = self._make_job(
+            run_id, "failure", "https://github.com/org/repo/actions/runs/55555/job/1"
+        )
+        run_metadata = {run_id: "Build and Test"}
+        result = self._bw._resolve_check_target_url(job, run_metadata, [])
+        self.assertEqual(result, "https://github.com/org/repo/actions/runs/55555/job/1")
+
+    def test_pending_ai_review(self):
+        run_id = 55555
+        job = self._make_job(
+            run_id, None, "https://github.com/org/repo/actions/runs/55555/job/1"
+        )
+        run_metadata = {run_id: "AI Code Review"}
+        result = self._bw._resolve_check_target_url(job, run_metadata, [])
+        self.assertEqual(result, "https://github.com/org/repo/actions/runs/55555/job/1")


### PR DESCRIPTION
When the AI Code Review workflow fails, link the patchwork check to
the PR review comment instead of the GitHub Actions job page. This
provides one-click access from patchwork to the actual review feedback.

Add _find_ai_review_comment_url() to locate the AI review comment by
matching the CI run summary URL embedded in the comment body.

Add _resolve_check_target_url() to dispatch between normal job URLs
and AI review comment URLs based on workflow name and job status.

Pre-fetch PR comments when AI review failures are present to avoid
redundant GitHub API calls.