### PR TITLE
kpd: ignore excluded workflows in CI email notifications

### DIFF
--- a/kernel_patches_daemon/branch_worker.py
+++ b/kernel_patches_daemon/branch_worker.py
@@ -1323,8 +1323,12 @@ class BranchWorker(GithubConnector):
         logger.info(f"Fetching workflow runs for {pr}: {pr.head.ref} (@ {pr.head.sha})")
 
         statuses: List[Status] = []
+        email_statuses: List[Status] = []
         jobs = []
         run_metadata: Dict[int, str] = {}
+        ignored_email_patterns = (
+            self.email_config.email_ignore_workflows if self.email_config else []
+        )
 
         # Note that we are interested in listing *all* runs and not just, say,
         # completed ones. The reason being that the information that pending
@@ -1361,9 +1365,12 @@ class BranchWorker(GithubConnector):
                             break
 
             statuses.append(status)
+            if not any(pat.search(run.name) for pat in ignored_email_patterns):
+                email_statuses.append(status)
             jobs += run_jobs
 
         status = process_statuses(statuses)
+        email_status = process_statuses(email_statuses)
         # In order to keep PW contexts somewhat deterministic, we sort the array
         # of jobs by name and later use the index of the test in the array to
         # generate the context name.
@@ -1401,7 +1408,7 @@ class BranchWorker(GithubConnector):
         ]
         await asyncio.gather(*tasks)
 
-        await self.evaluate_ci_result(status, series, pr, jobs)
+        await self.evaluate_ci_result(email_status, series, pr, jobs)
 
     async def evaluate_ci_result(
         self, status: Status, series: Series, pr: PullRequest, jobs: List[WorkflowJob]

--- a/kernel_patches_daemon/config.py
+++ b/kernel_patches_daemon/config.py
@@ -149,6 +149,7 @@ class EmailConfig:
     # submitters, unconditionally.
     ignore_allowlist: bool
     pr_comments_forwarding: Optional[PRCommentsForwardingConfig]
+    email_ignore_workflows: List[re.Pattern]
 
     @classmethod
     def from_json(cls, json: Dict) -> "EmailConfig":
@@ -168,6 +169,10 @@ class EmailConfig:
             pr_comments_forwarding=PRCommentsForwardingConfig.from_json(
                 json.get("pr_comments_forwarding", {})
             ),
+            email_ignore_workflows=[
+                re.compile(pattern)
+                for pattern in json.get("email_ignore_workflows", [])
+            ],
         )
 
 

--- a/tests/test_branch_worker.py
+++ b/tests/test_branch_worker.py
@@ -1307,6 +1307,7 @@ class TestEmailNotification(unittest.TestCase):
             ],
             ignore_allowlist=False,
             pr_comments_forwarding=None,
+            email_ignore_workflows=[],
         )
         expected_cmd = [
             "curl",
@@ -1369,6 +1370,7 @@ class TestEmailNotification(unittest.TestCase):
             ],
             ignore_allowlist=False,
             pr_comments_forwarding=None,
+            email_ignore_workflows=[],
         )
         expected_cmd = [
             "curl",
@@ -1429,6 +1431,7 @@ class TestEmailNotification(unittest.TestCase):
             ],
             ignore_allowlist=True,
             pr_comments_forwarding=None,
+            email_ignore_workflows=[],
         )
         expected_cmd = [
             "curl",
@@ -1946,3 +1949,182 @@ class TestResolveCheckTargetUrl(unittest.TestCase):
         run_metadata = {run_id: "AI Code Review"}
         result = self._bw._resolve_check_target_url(job, run_metadata, [])
         self.assertEqual(result, "https://github.com/org/repo/actions/runs/55555/job/1")
+
+
+class TestEmailWorkflowFiltering(unittest.IsolatedAsyncioTestCase):
+    """Tests for email_ignore_workflows filtering in sync_checks()."""
+
+    def setUp(self) -> None:
+        patcher = patch("kernel_patches_daemon.github_connector.Github")
+        self._gh_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _make_email_config(self, ignore_workflows=None):
+        return EmailConfig(
+            smtp_host="smtp.example.com",
+            smtp_port=465,
+            smtp_user="user",
+            smtp_from="from@example.com",
+            smtp_pass="pass",
+            smtp_to=[],
+            smtp_cc=[],
+            smtp_http_proxy=None,
+            submitter_allowlist=[],
+            ignore_allowlist=False,
+            pr_comments_forwarding=None,
+            email_ignore_workflows=ignore_workflows or [],
+        )
+
+    def _make_run(self, run_id, name, conclusion):
+        run = MagicMock()
+        run.id = run_id
+        run.name = name
+        run.conclusion = conclusion
+        run.jobs.return_value = []
+        return run
+
+    def _make_pr(self):
+        pr = MagicMock()
+        pr.html_url = "https://github.com/org/repo/pull/1"
+        pr.head.sha = "abc123"
+        pr.head.ref = "series/123=>branch"
+        pr.labels = []
+        pr.get_labels.return_value = []
+        pr.get_issue_comments.return_value = []
+        return pr
+
+    def _make_series(self):
+        pw = get_default_pw_client()
+        return Series(pw, SERIES_DATA)
+
+    async def test_ignored_workflow_excluded_from_email_status(self):
+        """A failing ignored workflow should not affect the email status."""
+        bw = BranchWorkerMock(
+            email=self._make_email_config(ignore_workflows=["AI Code Review"]),
+        )
+
+        runs = [
+            self._make_run(1, "Build and Test", "success"),
+            self._make_run(2, "AI Code Review", "failure"),
+        ]
+        bw.repo.get_workflow_runs.return_value = runs
+
+        pr = self._make_pr()
+        series = self._make_series()
+
+        with (
+            patch.object(bw, "evaluate_ci_result", new_callable=AsyncMock) as mock_eval,
+            patch.object(
+                bw, "submit_pr_summary", new_callable=AsyncMock
+            ) as mock_summary,
+        ):
+            await bw.sync_checks(pr, series)
+
+            mock_summary.assert_called_once()
+            summary_status = mock_summary.call_args.kwargs.get(
+                "status", mock_summary.call_args[1].get("status")
+            )
+            self.assertEqual(summary_status, Status.FAILURE)
+
+            mock_eval.assert_called_once()
+            eval_status = mock_eval.call_args[0][0]
+            self.assertEqual(eval_status, Status.SUCCESS)
+
+    async def test_no_ignored_workflows_all_count(self):
+        """With no ignored workflows, all statuses affect email status."""
+        bw = BranchWorkerMock(
+            email=self._make_email_config(ignore_workflows=[]),
+        )
+
+        runs = [
+            self._make_run(1, "Build and Test", "success"),
+            self._make_run(2, "AI Code Review", "failure"),
+        ]
+        bw.repo.get_workflow_runs.return_value = runs
+
+        pr = self._make_pr()
+        series = self._make_series()
+
+        with (
+            patch.object(bw, "evaluate_ci_result", new_callable=AsyncMock) as mock_eval,
+            patch.object(bw, "submit_pr_summary", new_callable=AsyncMock),
+        ):
+            await bw.sync_checks(pr, series)
+
+            eval_status = mock_eval.call_args[0][0]
+            self.assertEqual(eval_status, Status.FAILURE)
+
+    async def test_all_runs_ignored_email_status_is_skipped(self):
+        """When all runs are ignored, email status should be SKIPPED."""
+        bw = BranchWorkerMock(
+            email=self._make_email_config(ignore_workflows=["AI Code Review"]),
+        )
+
+        runs = [
+            self._make_run(1, "AI Code Review", "failure"),
+        ]
+        bw.repo.get_workflow_runs.return_value = runs
+
+        pr = self._make_pr()
+        series = self._make_series()
+
+        with (
+            patch.object(bw, "evaluate_ci_result", new_callable=AsyncMock) as mock_eval,
+            patch.object(bw, "submit_pr_summary", new_callable=AsyncMock),
+        ):
+            await bw.sync_checks(pr, series)
+
+            eval_status = mock_eval.call_args[0][0]
+            self.assertEqual(eval_status, Status.SKIPPED)
+
+    async def test_no_email_config_no_filtering(self):
+        """With no email config, ignored_email_workflows should be empty."""
+        bw = BranchWorkerMock(email=None)
+
+        runs = [
+            self._make_run(1, "Build and Test", "success"),
+            self._make_run(2, "AI Code Review", "failure"),
+        ]
+        bw.repo.get_workflow_runs.return_value = runs
+
+        pr = self._make_pr()
+        series = self._make_series()
+
+        with (
+            patch.object(bw, "evaluate_ci_result", new_callable=AsyncMock) as mock_eval,
+            patch.object(bw, "submit_pr_summary", new_callable=AsyncMock),
+        ):
+            await bw.sync_checks(pr, series)
+
+            eval_status = mock_eval.call_args[0][0]
+            self.assertEqual(eval_status, Status.FAILURE)
+
+    async def test_ignored_success_also_excluded(self):
+        """Even successful ignored workflows should be excluded from email status."""
+        bw = BranchWorkerMock(
+            email=self._make_email_config(ignore_workflows=["Lint"]),
+        )
+
+        runs = [
+            self._make_run(1, "Lint", "success"),
+        ]
+        bw.repo.get_workflow_runs.return_value = runs
+
+        pr = self._make_pr()
+        series = self._make_series()
+
+        with (
+            patch.object(bw, "evaluate_ci_result", new_callable=AsyncMock) as mock_eval,
+            patch.object(
+                bw, "submit_pr_summary", new_callable=AsyncMock
+            ) as mock_summary,
+        ):
+            await bw.sync_checks(pr, series)
+
+            summary_status = mock_summary.call_args.kwargs.get(
+                "status", mock_summary.call_args[1].get("status")
+            )
+            self.assertEqual(summary_status, Status.SUCCESS)
+
+            eval_status = mock_eval.call_args[0][0]
+            self.assertEqual(eval_status, Status.SKIPPED)

--- a/tests/test_branch_worker.py
+++ b/tests/test_branch_worker.py
@@ -1972,7 +1972,7 @@ class TestEmailWorkflowFiltering(unittest.IsolatedAsyncioTestCase):
             submitter_allowlist=[],
             ignore_allowlist=False,
             pr_comments_forwarding=None,
-            email_ignore_workflows=ignore_workflows or [],
+            email_ignore_workflows=[re.compile(p) for p in (ignore_workflows or [])],
         )
 
     def _make_run(self, run_id, name, conclusion):
@@ -2007,12 +2007,12 @@ class TestEmailWorkflowFiltering(unittest.IsolatedAsyncioTestCase):
             self._make_run(1, "Build and Test", "success"),
             self._make_run(2, "AI Code Review", "failure"),
         ]
-        bw.repo.get_workflow_runs.return_value = runs
 
         pr = self._make_pr()
         series = self._make_series()
 
         with (
+            patch.object(bw.repo, "get_workflow_runs", return_value=runs),
             patch.object(bw, "evaluate_ci_result", new_callable=AsyncMock) as mock_eval,
             patch.object(
                 bw, "submit_pr_summary", new_callable=AsyncMock
@@ -2040,12 +2040,12 @@ class TestEmailWorkflowFiltering(unittest.IsolatedAsyncioTestCase):
             self._make_run(1, "Build and Test", "success"),
             self._make_run(2, "AI Code Review", "failure"),
         ]
-        bw.repo.get_workflow_runs.return_value = runs
 
         pr = self._make_pr()
         series = self._make_series()
 
         with (
+            patch.object(bw.repo, "get_workflow_runs", return_value=runs),
             patch.object(bw, "evaluate_ci_result", new_callable=AsyncMock) as mock_eval,
             patch.object(bw, "submit_pr_summary", new_callable=AsyncMock),
         ):
@@ -2063,12 +2063,12 @@ class TestEmailWorkflowFiltering(unittest.IsolatedAsyncioTestCase):
         runs = [
             self._make_run(1, "AI Code Review", "failure"),
         ]
-        bw.repo.get_workflow_runs.return_value = runs
 
         pr = self._make_pr()
         series = self._make_series()
 
         with (
+            patch.object(bw.repo, "get_workflow_runs", return_value=runs),
             patch.object(bw, "evaluate_ci_result", new_callable=AsyncMock) as mock_eval,
             patch.object(bw, "submit_pr_summary", new_callable=AsyncMock),
         ):
@@ -2085,12 +2085,12 @@ class TestEmailWorkflowFiltering(unittest.IsolatedAsyncioTestCase):
             self._make_run(1, "Build and Test", "success"),
             self._make_run(2, "AI Code Review", "failure"),
         ]
-        bw.repo.get_workflow_runs.return_value = runs
 
         pr = self._make_pr()
         series = self._make_series()
 
         with (
+            patch.object(bw.repo, "get_workflow_runs", return_value=runs),
             patch.object(bw, "evaluate_ci_result", new_callable=AsyncMock) as mock_eval,
             patch.object(bw, "submit_pr_summary", new_callable=AsyncMock),
         ):
@@ -2108,12 +2108,12 @@ class TestEmailWorkflowFiltering(unittest.IsolatedAsyncioTestCase):
         runs = [
             self._make_run(1, "Lint", "success"),
         ]
-        bw.repo.get_workflow_runs.return_value = runs
 
         pr = self._make_pr()
         series = self._make_series()
 
         with (
+            patch.object(bw.repo, "get_workflow_runs", return_value=runs),
             patch.object(bw, "evaluate_ci_result", new_callable=AsyncMock) as mock_eval,
             patch.object(
                 bw, "submit_pr_summary", new_callable=AsyncMock
@@ -2128,3 +2128,27 @@ class TestEmailWorkflowFiltering(unittest.IsolatedAsyncioTestCase):
 
             eval_status = mock_eval.call_args[0][0]
             self.assertEqual(eval_status, Status.SKIPPED)
+
+    async def test_regex_pattern_matches_workflow(self):
+        """A regex pattern should match workflow names via search()."""
+        bw = BranchWorkerMock(
+            email=self._make_email_config(ignore_workflows=["AI.*"]),
+        )
+
+        runs = [
+            self._make_run(1, "Build and Test", "success"),
+            self._make_run(2, "AI Code Review", "failure"),
+        ]
+
+        pr = self._make_pr()
+        series = self._make_series()
+
+        with (
+            patch.object(bw.repo, "get_workflow_runs", return_value=runs),
+            patch.object(bw, "evaluate_ci_result", new_callable=AsyncMock) as mock_eval,
+            patch.object(bw, "submit_pr_summary", new_callable=AsyncMock),
+        ):
+            await bw.sync_checks(pr, series)
+
+            eval_status = mock_eval.call_args[0][0]
+            self.assertEqual(eval_status, Status.SUCCESS)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -180,6 +180,7 @@ class TestConfig(unittest.TestCase):
                     recipient_allowlist=[],
                     body_preprocessor_func=None,
                 ),
+                email_ignore_workflows=[],
             ),
             tag_to_branch_mapping={"tag": ["app_auth_key_path"]},
             branches={
@@ -220,3 +221,40 @@ class TestConfig(unittest.TestCase):
             base_directory="/repos",
         )
         self.assertEqual(config, expected_config)
+
+
+class TestEmailConfig(unittest.TestCase):
+    """Tests for EmailConfig parsing."""
+
+    def test_email_ignore_workflows_default(self):
+        """email_ignore_workflows defaults to empty list when not in config."""
+        cfg = EmailConfig.from_json(
+            {"host": "smtp.example.com", "user": "u", "from": "f@x.com", "pass": "p"}
+        )
+        self.assertEqual(cfg.email_ignore_workflows, [])
+
+    def test_email_ignore_workflows_parsed(self):
+        """email_ignore_workflows is correctly parsed from config."""
+        cfg = EmailConfig.from_json(
+            {
+                "host": "smtp.example.com",
+                "user": "u",
+                "from": "f@x.com",
+                "pass": "p",
+                "email_ignore_workflows": ["AI Code Review", "Lint"],
+            }
+        )
+        self.assertEqual(cfg.email_ignore_workflows, ["AI Code Review", "Lint"])
+
+    def test_email_ignore_workflows_empty_list(self):
+        """email_ignore_workflows accepts an explicit empty list."""
+        cfg = EmailConfig.from_json(
+            {
+                "host": "smtp.example.com",
+                "user": "u",
+                "from": "f@x.com",
+                "pass": "p",
+                "email_ignore_workflows": [],
+            }
+        )
+        self.assertEqual(cfg.email_ignore_workflows, [])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -234,7 +234,7 @@ class TestEmailConfig(unittest.TestCase):
         self.assertEqual(cfg.email_ignore_workflows, [])
 
     def test_email_ignore_workflows_parsed(self):
-        """email_ignore_workflows is correctly parsed from config."""
+        """email_ignore_workflows is correctly parsed as compiled regex patterns."""
         cfg = EmailConfig.from_json(
             {
                 "host": "smtp.example.com",
@@ -244,7 +244,26 @@ class TestEmailConfig(unittest.TestCase):
                 "email_ignore_workflows": ["AI Code Review", "Lint"],
             }
         )
-        self.assertEqual(cfg.email_ignore_workflows, ["AI Code Review", "Lint"])
+        self.assertEqual(len(cfg.email_ignore_workflows), 2)
+        for pat in cfg.email_ignore_workflows:
+            self.assertIsInstance(pat, re.Pattern)
+        self.assertIsNotNone(cfg.email_ignore_workflows[0].search("AI Code Review"))
+        self.assertIsNotNone(cfg.email_ignore_workflows[1].search("Lint"))
+
+    def test_email_ignore_workflows_regex(self):
+        """email_ignore_workflows supports regex patterns."""
+        cfg = EmailConfig.from_json(
+            {
+                "host": "smtp.example.com",
+                "user": "u",
+                "from": "f@x.com",
+                "pass": "p",
+                "email_ignore_workflows": ["AI.*Review"],
+            }
+        )
+        self.assertEqual(len(cfg.email_ignore_workflows), 1)
+        self.assertIsNotNone(cfg.email_ignore_workflows[0].search("AI Code Review"))
+        self.assertIsNone(cfg.email_ignore_workflows[0].search("Build and Test"))
 
     def test_email_ignore_workflows_empty_list(self):
         """email_ignore_workflows accepts an explicit empty list."""


### PR DESCRIPTION
Add email_ignore_workflows config field to EmailConfig as a list of
regex patterns. Workflow names matching any pattern are excluded from
the aggregate status used for email notification decisions. This
prevents AI review workflow failures from triggering CI failure emails.

The unfiltered status is still used for patchwork check reporting
and PR summary, ensuring accurate CI visibility. Only the email
notification path uses the filtered status.