### PR TITLE
docker: fix base image (python:3-slim) + build on PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,7 @@
 name: Docker Image Publish
 
 on:
+  pull_request:
   workflow_run:
     workflows: ["Python Test"]
     branches: [main]
@@ -11,8 +12,25 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  # Validate the image builds on every PR, without publishing.
+  build-image:
+    name: Build image (no push)
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false
+
   build-and-push-image:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -39,7 +57,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
   exit-with-error:
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest
     steps:
       - run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-bullseye as builder
+FROM python:3-slim as builder
 
 RUN pip install poetry
 
@@ -9,13 +9,13 @@ ENV POETRY_NO_INTERACTION=1 \
 
 WORKDIR /app
 
-COPY pyproject.toml /app/pyproject.toml
+COPY pyproject.toml poetry.lock /app/
 RUN touch README.md
 
 RUN poetry install --without dev --no-root && rm -rf $POETRY_CACHE_DIR
 
 # The runtime image, used to just run the code provided its virtual environment
-FROM python:3.9-bullseye as runtime
+FROM python:3-slim as runtime
 LABEL maintainer="Ihor Solodrai <isolodrai@meta.com>"
 
 RUN apt update && \


### PR DESCRIPTION
Fixes the broken Docker Image Publish workflow and makes the image build on PRs
so it can't silently regress again.

**Fix the build.** The Dockerfile pinned `python:3.10-bullseye` (builder) /
`python:3.9-bullseye` (runtime). After the project floor moved to `^3.11`,
`poetry install` in the 3.10 builder failed (*"3.10.18 is not supported by the
project (^3.11)"*). Switch both stages to `python:3-slim` (latest 3.x): it
always satisfies the constraint with no version to keep in sync, fixes the
latent builder/runtime interpreter mismatch (the copied `.venv` was built on
3.10 but run on 3.9), and shrinks the image. Also `COPY poetry.lock` for a
reproducible install.

**Validate on PRs.** Add a build-only job (`push: false`) gated to
`pull_request`; the existing publish/error jobs stay gated to the `main`
`workflow_run`. A broken Dockerfile is now caught at PR time instead of
post-merge.

Verified locally on `python:3-slim`: `poetry install` from the lock succeeds,
all C-extension deps import, and `python -m kernel_patches_daemon --help` runs.
