### PR TITLE
Followups to addition of --no-metrics option

### DIFF
--- a/kernel_patches_daemon/daemon.py
+++ b/kernel_patches_daemon/daemon.py
@@ -34,6 +34,10 @@ class KernelPatchesWorker:
         self.labels_cfg = labels_cfg
         self.loop_delay: Final[int] = loop_delay
         self.metrics_logger = metrics_logger
+        if self.metrics_logger is None:
+            logger.info(
+                "Metrics logging is disabled; run metrics will not be submitted"
+            )
         self.github_sync_worker: GithubSync = GithubSync(
             kpd_config=self.kpd_config, labels_cfg=self.labels_cfg
         )
@@ -53,10 +57,7 @@ class KernelPatchesWorker:
 
     async def submit_metrics(self) -> None:
         if self.metrics_logger is None:
-            # pyrefly: ignore  # deprecated
-            logger.warn(
-                "Not submitting run metrics because metrics logger is not configured"
-            )
+            # Metrics are intentionally disabled (see __init__); nothing to do.
             return
         try:
             self.metrics_logger(self.project, self.github_sync_worker.stats)

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -106,3 +106,35 @@ class TestKernelPatchesWorker(unittest.IsolatedAsyncioTestCase):
         stats = LOGGED_METRICS[0][self.worker.project]
         self.assertEqual(stats["runs_failed"], 1)
         self.assertEqual(stats["unhandled_ValueError"], 1)
+
+    def _build_worker(self, metrics_logger) -> KernelPatchesWorker:
+        kpd_config = KPDConfig.from_json(TEST_CONFIG)
+        return KernelPatchesWorker(kpd_config, {}, metrics_logger=metrics_logger)
+
+    def test_disabled_metrics_logged_once_at_startup(self) -> None:
+        """When no metrics logger is configured, log about it once at startup."""
+        with patch("kernel_patches_daemon.daemon.logger") as logger_mock:
+            self._build_worker(None)
+
+        disabled_logs = [
+            call
+            for call in logger_mock.info.call_args_list
+            if "Metrics logging is disabled" in call.args[0]
+        ]
+        self.assertEqual(len(disabled_logs), 1)
+
+    async def test_submit_metrics_silent_without_logger(self) -> None:
+        """submit_metrics() must not warn on every call when metrics are off.
+
+        It is invoked on each iteration of the main loop, so a warning there
+        would spam the logs when running with --no-metrics.
+        """
+        worker = self._build_worker(None)
+
+        with patch("kernel_patches_daemon.daemon.logger") as logger_mock:
+            await worker.submit_metrics()
+            await worker.submit_metrics()
+
+        logger_mock.warning.assert_not_called()
+        logger_mock.warn.assert_not_called()
+        logger_mock.info.assert_not_called()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,96 @@
+import json
+import os
+import runpy
+import sys
+import tempfile
+import unittest
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+TEST_CONFIG: Dict[str, Any] = {
+    "version": 3,
+    "patchwork": {
+        "project": "test",
+        "server": "pw",
+        "search_patterns": ["pw-search-pattern"],
+        "lookback": 7,
+    },
+    "branches": {
+        "test-branch": {
+            "repo": "repo",
+            "github_oauth_token": "test-oauth-token",
+            "upstream": "https://127.0.0.2:0/upstream_org/upstream_repo",
+            "ci_repo": "ci-repo",
+            "ci_branch": "test_ci_branch",
+        },
+    },
+    "tag_to_branch_mapping": {
+        "tag": ["test-branch"],
+        "__DEFAULT__": ["test-branch"],
+    },
+    "base_directory": "/tmp",
+}
+
+
+class TestNoMetricsOption(unittest.TestCase):
+    """Exercise the kernel_patches_daemon.__main__ entry point as-is.
+
+    The daemon is mocked out so start() does not block; we then inspect the
+    real `metrics_logger` global the entry point computed from the CLI args.
+    """
+
+    def setUp(self) -> None:
+        self._tmpfiles: List[str] = []
+
+    def tearDown(self) -> None:
+        for path in self._tmpfiles:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+
+    def _write_tmp_json(self, data: Any) -> str:
+        fd, path = tempfile.mkstemp(suffix=".json")
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f)
+        self._tmpfiles.append(path)
+        return path
+
+    def _run_main(self, extra_argv: List[str]) -> Dict[str, Any]:
+        cfg_path = self._write_tmp_json(TEST_CONFIG)
+        labels_path = self._write_tmp_json({})
+        argv = [
+            "kpd",
+            "--config",
+            cfg_path,
+            "--label-colors",
+            labels_path,
+        ] + extra_argv
+        with (
+            patch.object(sys, "argv", argv),
+            patch("kernel_patches_daemon.daemon.KernelPatchesDaemon"),
+        ):
+            return runpy.run_module(
+                "kernel_patches_daemon.__main__", run_name="__main__"
+            )
+
+    def test_no_metrics_disables_metrics_logger(self) -> None:
+        """When --no-metrics is passed, metrics_logger is None."""
+        ns = self._run_main(["--no-metrics"])
+        self.assertIsNone(ns["metrics_logger"])
+
+    def test_metrics_logger_enabled_by_default(self) -> None:
+        """Without --no-metrics, a metrics_logger callable is configured."""
+        with (
+            patch("opentelemetry.sdk.metrics.MeterProvider"),
+            patch("opentelemetry.sdk.metrics.export.PeriodicExportingMetricReader"),
+            patch("opentelemetry.sdk.metrics.export.ConsoleMetricExporter"),
+            patch("opentelemetry.metrics.set_meter_provider"),
+        ):
+            ns = self._run_main([])
+        self.assertIsNotNone(ns["metrics_logger"])
+        self.assertTrue(callable(ns["metrics_logger"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

- **Add self-test for --no-metrics command line option**
- **Log disabled metrics once instead of warning on every iteration**
- **Add tests for disabled metrics logging**
