### PR TITLE
Fix parameter duplication in patchwork query

### DIFF
--- a/kernel_patches_daemon/patchwork.py
+++ b/kernel_patches_daemon/patchwork.py
@@ -620,6 +620,12 @@ class Patchwork:
             # Here all a sudden, path is changed from a "relative path" to the full URL. Luckily, urljoin, which we use
             # in `__get` deal with this and compute the right URL.
             path = str(response.links["next"]["url"])
+            # The `next` URL already carries all the query parameters, so pass an
+            # empty mapping instead of the original filters: aiohttp appends
+            # (rather than replaces) params, so re-passing them would duplicate
+            # every filter on each page and grow the URL until the server rejects
+            # the request.
+            params = {}
         return items
 
     async def __post(self, path: AnyStr, data: Dict) -> aiohttp.ClientResponse:

--- a/tests/test_patchwork.py
+++ b/tests/test_patchwork.py
@@ -181,6 +181,49 @@ class TestPatchwork(PatchworkTestCase):
                     )
 
     @aioresponses()
+    async def test_get_objects_recursive_no_param_duplication(
+        self, m: aioresponses
+    ) -> None:
+        """Regression test: query params must not be duplicated across pages.
+
+        The `next` link returned by Patchwork already contains all the query
+        parameters. They must not be re-appended on the follow-up request, or
+        every filter would be duplicated on each page, growing the URL until
+        the server rejects it.
+        """
+        base = "https://127.0.0.1/api/1.1/projects/"
+        # Page 1: filtered request; its `next` link already carries the filters.
+        m.get(
+            base + "?k1=v1&k2=v2",
+            status=200,
+            headers={"Link": f'<{base}?k1=v1&k2=v2&page=2>; rel="next"'},
+            body=b'["a"]',
+        )
+        # Page 2: must be requested verbatim, with each filter present once.
+        m.get(
+            base + "?k1=v1&k2=v2&page=2",
+            status=200,
+            headers={},
+            body=b'["b"]',
+        )
+
+        # pyrefly: ignore  # missing-attribute
+        resp = await self._pw._Patchwork__get_objects_recursive(
+            "projects", params={"k1": "v1", "k2": "v2"}
+        )
+
+        self.assertEqual(resp, ["a", "b"])
+        # No request may carry a duplicated query parameter.
+        # pyrefly: ignore  # not-iterable
+        for method, req_url in m.requests:
+            for param in ("k1", "k2"):
+                self.assertLessEqual(
+                    len(req_url.query.getall(param, [])),
+                    1,
+                    f"param {param!r} duplicated in {req_url}",
+                )
+
+    @aioresponses()
     async def test_try_post_nocred_nomutation(self, m: aioresponses) -> None:
         """
         When pw_token is not set or is an empty string, we will not call post.


### PR DESCRIPTION

When running KPD against linux-mm patchwork with lookback of 14 I hit an
exception because patchowrk rejected a request URL with 502:

```
File "/home/mike/git/kernel-patches-daemon/.venv/lib/python3.12/site-packages/aiohttp/client_reqrep.py", line 756, in json
    raise ContentTypeError(
aiohttp.client_exceptions.ContentTypeError: 502, message='Attempt to decode JSON with unexpected mimetype: text/html; charset=utf-8', url='https://patchwork.kernel.org/api/1.2/patches/?archived=False&archived=False&archived=False&archived=False&archived=False&archived=False&archived=False&archived=False&page=9&project=365&project=365&project=365&project=365&project=365&project=365&project=365&project=365&since=2026-06-14T00:00:00&since=2026-06-14T00:00:00&since=2026-06-14T00:00:00&since=2026-06-14T00:00:00&since=2026-06-14T00:00:00&since=2026-06-14T00:00:00&since=2026-06-14T00:00:00&since=2026-06-14T00:00:00&state=1&state=2&state=5&state=7&state=13&state=15&state=1&state=2&state=5&state=7&state=13&state=15&state=1&state=2&state=5&state=7&state=13&state=15&state=1&state=2&state=5&state=7&state=13&state=15&state=1&state=2&state=5&state=7&state=13&state=15&state=1&state=2&state=5&state=7&state=13&state=15&state=1&state=2&state=5&state=7&state=13&state=15&state=1&state=2&state=5&state=7&state=13&state=15&archived=False&state=1&state=2&state=5&state=7&state=13&state=15&since=2026-06-14T00:00:00&project=365'
```
  
This is a fix suggested by an LLM.
