### PR TITLE
branch_worker: fix _is_outdated_pr closing active PRs with >250 commits

### DIFF
--- a/kernel_patches_daemon/branch_worker.py
+++ b/kernel_patches_daemon/branch_worker.py
@@ -635,15 +635,31 @@ def _is_outdated_pr(pr: PullRequest) -> bool:
     """
     Check if a pull request is outdated, i.e., whether it has not seen an update recently.
     """
-    commits = pr.get_commits()
-    if commits.totalCount == 0:
+    # Defensive guard: without a resolvable HEAD SHA there is no commit to
+    # inspect, so treat the PR as not outdated.
+    if not pr.head or not pr.head.sha:
         return False
 
-    # We only look at the most recent commit, which should be the last one. If
-    # a user modified an earlier one, the magic of Git ensures that any commits
-    # that have it as a parent will also be changed.
-    commit = commits[commits.totalCount - 1]
-    last_modified = dateutil.parser.parse(commit.stats.last_modified)
+    # We only look at the most recent commit, i.e., the branch's HEAD. If a user
+    # modified an earlier one, the magic of Git ensures that any commits that
+    # have it as a parent will also be changed.
+    #
+    # We fetch the HEAD commit directly by SHA rather than paginating through
+    # pr.get_commits(): GitHub's "List PR commits" endpoint caps its result at
+    # 250 commits (returned oldest-first), so for PRs with more than 250 commits
+    # the last entry it hands back is the 250th *oldest* commit -- not the most
+    # recent one. Relying on it made us age active PRs past the TTL and close
+    # them as stale. Fetching by SHA has no such cap.
+    try:
+        head_commit = pr.base.repo.get_commit(pr.head.sha)
+    except GithubException as e:
+        # The HEAD commit may be transiently unresolvable -- e.g. the branch was
+        # deleted and the commit garbage collected, or a force-push raced with
+        # the open-PR snapshot we are iterating. Err on the side of keeping the
+        # PR: better to leave it open than to close a PR we cannot assess.
+        logger.warning(f"Could not fetch HEAD commit for {pr}: {e}")
+        return False
+    last_modified = dateutil.parser.parse(head_commit.stats.last_modified)
     # pyrefly: ignore  # unsupported-operation
     age = datetime.now(timezone.utc) - last_modified
     logger.info(f"Pull request {pr} has age {age}")

--- a/tests/test_branch_worker.py
+++ b/tests/test_branch_worker.py
@@ -25,8 +25,10 @@ import git
 from aioresponses import aioresponses
 from freezegun import freeze_time
 from git.exc import GitCommandError
+from github import GithubException
 from kernel_patches_daemon.branch_worker import (
     _is_branch_changed,
+    _is_outdated_pr,
     _series_already_applied,
     ALREADY_MERGED_LOOKBACK,
     BRANCH_TTL,
@@ -947,6 +949,78 @@ class TestSupportFunctions(unittest.TestCase):
             pr1 = create_mock_pr("Fix memory leak", "invalid-ref-format")
             pr2 = create_mock_pr("Different title", "also-invalid")
             self.assertFalse(prs_for_the_same_series(pr1, pr2))
+
+    def test_is_outdated_pr(self) -> None:
+        def create_mock_pr(
+            last_modified: str, head_sha: Optional[str] = "abc123"
+        ) -> MagicMock:
+            pr = MagicMock()
+            pr.head.sha = head_sha
+            commit = MagicMock()
+            commit.stats.last_modified = last_modified
+            pr.base.repo.get_commit.return_value = commit
+            return pr
+
+        # Freeze "now" so the ages below are deterministic (TTL is 7 days).
+        with freeze_time("2024-01-30 00:00:00"):
+            with self.subTest("recent_head_commit_not_outdated"):
+                # HEAD commit modified 1 day ago -> not outdated. Crucially, we
+                # fetch the HEAD commit by SHA and never paginate get_commits(),
+                # whose 250-commit cap made us wrongly age PRs with >250 commits.
+                pr = create_mock_pr("Mon, 29 Jan 2024 00:00:00 GMT")
+                self.assertFalse(_is_outdated_pr(pr))
+                pr.base.repo.get_commit.assert_called_once_with("abc123")
+                pr.get_commits.assert_not_called()
+
+            with self.subTest("old_head_commit_outdated"):
+                # HEAD commit modified 10 days ago -> outdated (older than TTL).
+                pr = create_mock_pr("Sat, 20 Jan 2024 00:00:00 GMT")
+                self.assertTrue(_is_outdated_pr(pr))
+                pr.get_commits.assert_not_called()
+
+            with self.subTest("head_commit_age_exactly_ttl_not_outdated"):
+                # Exactly PULL_REQUEST_TTL (7 days) old. The comparison is strict
+                # (`age > TTL`), so the boundary is NOT outdated; this pins the
+                # operator against an accidental flip to `>=`.
+                pr = create_mock_pr("Tue, 23 Jan 2024 00:00:00 GMT")
+                self.assertFalse(_is_outdated_pr(pr))
+
+            with self.subTest("stale_250th_commit_ignored_uses_head"):
+                # Directly reproduce the bug: for a PR with >250 commits,
+                # get_commits() is capped at 250 (oldest-first), so its "last"
+                # entry is a stale old commit while the true HEAD is fresh. The
+                # fix must judge the PR by HEAD, not by that stale entry. Against
+                # the old implementation this asserts False->True and fails
+                # cleanly, so it is a genuine regression guard.
+                pr = create_mock_pr("Mon, 29 Jan 2024 00:00:00 GMT")
+                stale_commit = MagicMock()
+                stale_commit.stats.last_modified = "Wed, 03 Jan 2024 00:00:00 GMT"
+                capped = MagicMock()
+                capped.totalCount = 250
+                capped.__getitem__.return_value = stale_commit
+                pr.get_commits.return_value = capped
+                self.assertFalse(_is_outdated_pr(pr))
+
+            with self.subTest("unresolvable_head_commit_not_outdated"):
+                # If the HEAD commit cannot be fetched (deleted branch, gc'd
+                # commit, or a force-push racing the open-PR snapshot), keep the
+                # PR rather than close one we cannot assess.
+                pr = create_mock_pr("Mon, 29 Jan 2024 00:00:00 GMT")
+                pr.base.repo.get_commit.side_effect = GithubException(404, None, None)
+                self.assertFalse(_is_outdated_pr(pr))
+
+            with self.subTest("missing_head_sha_not_outdated"):
+                # Defensive: a PR whose HEAD SHA is absent is not assessed.
+                pr = create_mock_pr("Sat, 20 Jan 2024 00:00:00 GMT", head_sha=None)
+                self.assertFalse(_is_outdated_pr(pr))
+                pr.base.repo.get_commit.assert_not_called()
+
+            with self.subTest("missing_head_not_outdated"):
+                # Defensive: a PR with no head part at all is not assessed.
+                pr = create_mock_pr("Sat, 20 Jan 2024 00:00:00 GMT")
+                pr.head = None
+                self.assertFalse(_is_outdated_pr(pr))
+                pr.base.repo.get_commit.assert_not_called()
 
 
 class TestGitSeriesAlreadyApplied(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
GitHub's "List PR commits" endpoint caps its result at 250 commits, returned oldest-first. For a PR with more than 250 commits, pr.get_commits()[totalCount - 1] is therefore the 250th *oldest* commit, not the HEAD, so its Last-Modified aged past PULL_REQUEST_TTL and expire_user_prs() wrongly closed active PRs as stale.

Fetch the HEAD commit directly by SHA (pr.base.repo.get_commit), which has no such cap. Guard a missing HEAD SHA, and treat an unresolvable HEAD commit (deleted branch, gc'd commit, force-push race) as not outdated so a single PR cannot abort the expiry cycle.

Add tests, including one that reproduces the >250-commit case and fails cleanly against the old implementation.